### PR TITLE
Using the dvh to make the viewport height dynamic

### DIFF
--- a/IndoorMapsFrontend/src/App.css
+++ b/IndoorMapsFrontend/src/App.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
 }
 
 footer {


### PR DESCRIPTION
(no normal message length because this is just a 1 line change)
On mobile 100vh includes the address bar while 100% does not. The new dvh unit should adjust the reported height as the address bar hides itself. It is possible that this results in poor performance in which case other solutions will be tested
https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser/72245072#72245072
https://caniuse.com/viewport-unit-variants