### PR TITLE
Specify a guide image to help with area layouts

### DIFF
--- a/IndoorMapsBackend/prisma/migrations/20240722221724_guide_image/migration.sql
+++ b/IndoorMapsBackend/prisma/migrations/20240722221724_guide_image/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Floor" ADD COLUMN     "guideImage" TEXT,
+ADD COLUMN     "guideImageShape" JSONB;

--- a/IndoorMapsBackend/prisma/migrations/20240722235716_rotation_as_float/migration.sql
+++ b/IndoorMapsBackend/prisma/migrations/20240722235716_rotation_as_float/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Floor" ADD COLUMN     "guideImageRotation" DOUBLE PRECISION;

--- a/IndoorMapsBackend/prisma/schema.prisma
+++ b/IndoorMapsBackend/prisma/schema.prisma
@@ -19,16 +19,19 @@ model User {
 }
 
 model Floor {
-  id             Int      @id @default(autoincrement())
-  areas          Area[]
-  title          String
-  description    String
-  building       Building @relation(fields: [buildingId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  buildingId     Int
-  shape          Json?
-  navMesh        Json?
-  voronoiNavMesh Json?
-  walls          Json?
+  id                 Int      @id @default(autoincrement())
+  areas              Area[]
+  title              String
+  description        String
+  building           Building @relation(fields: [buildingId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  buildingId         Int
+  shape              Json?
+  navMesh            Json?
+  voronoiNavMesh     Json?
+  walls              Json?
+  guideImage         String?
+  guideImageShape    Json?
+  guideImageRotation Float?
 }
 
 model Building {

--- a/IndoorMapsBackend/src/graphqlSchemaTypes/Floor.ts
+++ b/IndoorMapsBackend/src/graphqlSchemaTypes/Floor.ts
@@ -1,4 +1,4 @@
-import { Field, ID, Int, ObjectType } from "type-graphql"
+import { Field, Float, ID, Int, ObjectType } from "type-graphql"
 
 import { MutationResult } from '../utils/generic.js'
 
@@ -28,4 +28,13 @@ export class Floor {
 
   @Field({ nullable: true })
   shape?: string
+
+  @Field({ nullable: true })
+  guideImage?: string
+
+  @Field({ nullable: true })
+  guideImageShape?: string
+
+  @Field(type => Float, { nullable: true })
+  guideImageRotation?: number
 }

--- a/IndoorMapsBackend/src/resolvers/FloorResolver.ts
+++ b/IndoorMapsBackend/src/resolvers/FloorResolver.ts
@@ -1,4 +1,4 @@
-import { Arg, Ctx, Field, FieldResolver, InputType, Int, Mutation, Query, Resolver, Root } from "type-graphql";
+import { Arg, Ctx, Field, FieldResolver, Float, InputType, Int, Mutation, Query, Resolver, Root } from "type-graphql";
 
 import { Context, prisma } from "../utils/context.js";
 import { convertToGraphQLFloor, convertToGraphQlArea } from "../utils/typeConversions.js";
@@ -43,6 +43,15 @@ class FloorModifyInput extends FloorUniqueInput {
     // because a shape can be null, I added 2 layers of nullable. The first layer specifies whether the shape should be updated and the seccond specified the new shape value (which is possibly null)
     @Field(type => NewShape, { nullable: true, description: "If New Shape is null there is no update, otherwise shape is updated to the shape inside of NewShape" })
     newShape?: NewShape
+
+    @Field({ nullable: true })
+    guideImage?: string
+
+    @Field(type => NewShape, { nullable: true })
+    newGuideImageShape?: NewShape
+
+    @Field(type => Float, { nullable: true })
+    guideImageRotation?: number
 }
 
 export const deleteNavMesh = async (floorDatabaseId: number) => {
@@ -96,7 +105,10 @@ export class FloorResolver {
             data: {
                 description: data.description,
                 title: data.title,
-                shape: data.newShape !== undefined ? JSON.parse(data.newShape.shape) : undefined
+                shape: data.newShape !== undefined ? JSON.parse(data.newShape.shape) : undefined,
+                guideImage: data.guideImage,
+                guideImageShape: data.newGuideImageShape !== undefined ? JSON.parse(data.newGuideImageShape.shape) : undefined,
+                guideImageRotation: data.guideImageRotation,
             },
         });
         await deleteNavMesh(data.id);

--- a/IndoorMapsBackend/src/utils/typeConversions.ts
+++ b/IndoorMapsBackend/src/utils/typeConversions.ts
@@ -33,8 +33,11 @@ export const convertToGraphQLBuilding = (buildingFromDB: DbBuilding): Building =
 export const convertToGraphQLFloor = (floorFromDB: DbFloor): Floor => {
     const floor: Floor = {
         ...floorFromDB,
+        guideImage: floorFromDB.guideImage !== null ? floorFromDB.guideImage : undefined,
+        guideImageShape: floorFromDB.guideImageShape !== null ? JSON.stringify(floorFromDB.guideImageShape) : undefined,
         shape: floorFromDB.shape !== null ? JSON.stringify(floorFromDB.shape) : undefined,
         databaseId: floorFromDB.id,
+        guideImageRotation: floorFromDB.guideImageRotation ? floorFromDB.guideImageRotation : undefined,
         id: "floor" + floorFromDB.id.toString()
     }
     return floor;

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/EditorSidebar.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/EditorSidebar.tsx
@@ -40,6 +40,7 @@ const floorMapLayer = L.geoJSON(null, {
     return L.marker(latlng, {icon: DoorMarkerIcon});
   }
 });
+const imageOverlayMapLayer = L.geoJSON();
 const areasMapLayer = L.geoJSON();
 const areaEntranceMapLayer = L.geoJSON();
 
@@ -132,7 +133,7 @@ const EditorSidebar = ({ buildingFromParent, map }: Props) => {
       {isAreaSidebarOpen ?
         <AreaSidebar buildingId={building.databaseId} closeSidebar={handleCloseAreaSidebar} floorFromParent={building.floors.find((floor) => floor.databaseId == currentFloor)} map={map} areasMapLayer={areasMapLayer} areaEntranceMapLayer={areaEntranceMapLayer} />
         :
-        <FloorSidebar openAreaSidebar={handleOpenAreaSidebar} setCurrentFloor={handleFloorChange} floorMapLayer={floorMapLayer} currentFloor={currentFloor} buildingFromParent={building} map={map} />
+        <FloorSidebar imageOverlayMapLayer={imageOverlayMapLayer} openAreaSidebar={handleOpenAreaSidebar} setCurrentFloor={handleFloorChange} floorMapLayer={floorMapLayer} currentFloor={currentFloor} buildingFromParent={building} map={map} />
       }
     </aside>
   )

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/EditorSidebar.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/EditorSidebar.tsx
@@ -118,6 +118,12 @@ const EditorSidebar = ({ buildingFromParent, map }: Props) => {
     })
     map.pm.disableDraw();
     map.pm.disableGlobalRotateMode();
+
+    imageOverlayMapLayer.getLayers().map((layer) => {
+      if (layer instanceof L.ImageOverlay || layer instanceof L.Rectangle) {
+        layer.setStyle({ stroke: false, fill: false });
+      }
+    })
     openAreaSidebar();
   }
 

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
@@ -16,12 +16,17 @@ const FloorSidebarFragment = graphql`
   {
     id
     databaseId
+    startPos {
+      lat
+      lon
+    }
     floors {
       id
       databaseId
       title
       shape
       ...FloorListItemFragment
+      ...GuideImageFragment
     }
   }
 `;
@@ -33,9 +38,10 @@ type Props = {
     floorMapLayer: L.GeoJSON;
     setCurrentFloor: (floor: number) => void;
     openAreaSidebar: () => void;
+    imageOverlayMapLayer: L.GeoJSON;
 }
 
-const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, setCurrentFloor, openAreaSidebar }: Props) => {
+const FloorSidebar = ({imageOverlayMapLayer, buildingFromParent, map, currentFloor, floorMapLayer, setCurrentFloor, openAreaSidebar }: Props) => {
     const building = useFragment(FloorSidebarFragment, buildingFromParent);
     const [isCreateFloorModalOpen, handleCloseCreateFloorModal, handleOpenCreateFloorModal] = useBooleanState(false);
     const [formError, setFormError] = useState<string | null>(null);
@@ -45,6 +51,7 @@ const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, se
     mutation FloorSidebarFloorMutation($data: FloorModifyInput!) {
         modifyFloor(data: $data) {
             ...FloorListItemFragment
+            ...GuideImageFragment
         }
     }
     `);
@@ -142,6 +149,7 @@ const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, se
                 layer.on('pm:edit', onShapeEdit)
                 layer.on('pm:remove', onShapeRemove)
             })
+            imageOverlayMapLayer.addTo(map)
         }
 
     }, [currentFloor])
@@ -160,7 +168,7 @@ const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, se
             <ScrollArea h={250}>
                 {floorListElements}
             </ScrollArea>
-            <GuideImage map={map} floorMapLayer={floorMapLayer} setFormError={(e: string) => setFormError(e)} />
+            {currentFloorData ? <GuideImage key={currentFloorData.id} startPos={building.startPos} imageOverlayMapLayer={imageOverlayMapLayer} modifyFloor={modifyFloor} currentFloorData={currentFloorData} map={map} setFormError={(e: string) => setFormError(e)} /> : null}
             <CreateFloorModal isOpen={isCreateFloorModalOpen} closeModal={handleCloseCreateFloorModal} />
             <div>{isInFlight ? "saving ..." : "all saved"}</div>
         </>

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
@@ -11,7 +11,6 @@ import * as L from "leaflet";
 import { removeAllLayersFromLayerGroup } from "../../utils/utils";
 import GuideImage from "./GuideImage";
 
-
 const FloorSidebarFragment = graphql`
   fragment FloorSidebarBodyFragment on Building
   {

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/FloorSidebar.tsx
@@ -9,6 +9,7 @@ import { useBooleanState } from "../../utils/hooks";
 import { FloorSidebarFloorMutation, FloorSidebarFloorMutation$variables } from "./__generated__/FloorSidebarFloorMutation.graphql";
 import * as L from "leaflet";
 import { removeAllLayersFromLayerGroup } from "../../utils/utils";
+import GuideImage from "./GuideImage";
 
 
 const FloorSidebarFragment = graphql`
@@ -89,7 +90,7 @@ const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, se
         if (!map) return;
         floorMapLayer.removeLayer(event.layer);
         handleFloorShapeUpdate()
-        if(event.layer instanceof L.Polygon){
+        if (event.layer instanceof L.Polygon) {
             setWhetherBuildingOrEntrenceMapping(false);
         }
     }
@@ -153,13 +154,14 @@ const FloorSidebar = ({ buildingFromParent, map, currentFloor, floorMapLayer, se
             <FormErrorNotification formError={formError} onClose={() => { setFormError(null) }} />
             <h2>Editor Sidebar {currentFloorData ?
                 <Button onClick={openAreaSidebar}>Edit {currentFloorData.title} Areas</Button>
-            : null}</h2>
+                : null}</h2>
             <Tooltip zIndex={50} opened={currentFloor === null} label="Create your first floor to get started">
                 <Button onClick={handleOpenCreateFloorModal}>New Floor</Button>
             </Tooltip>
             <ScrollArea h={250}>
                 {floorListElements}
             </ScrollArea>
+            <GuideImage map={map} floorMapLayer={floorMapLayer} setFormError={(e: string) => setFormError(e)} />
             <CreateFloorModal isOpen={isCreateFloorModalOpen} closeModal={handleCloseCreateFloorModal} />
             <div>{isInFlight ? "saving ..." : "all saved"}</div>
         </>

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -188,6 +188,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
     return (
         <>
             <canvas style={{ display: "none" }} ref={canvas} id="tutorial" width="600" height="600"></canvas>
+            <i>Guide Image is currently experimental</i>
             <TextInput label="Guide Image Url" placeholder="Enter Guide Image Url" value={guideImageUrl} onChange={(e) => setGuideImageUrl(e.target.value)} />
             <p>Consider using <a href="https://imgbb.com/">https://imgbb.com/</a> to upload your image, then copy the embed url</p>
         </>

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -60,7 +60,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             guideBoundingRect = L.rectangle(startingLatLngBounds).addTo(imageOverlayMapLayer);
         }
 
-        const imageOverlay = L.imageOverlay(guideImageUrl, guideBoundingRect.getBounds(), {
+        const imageOverlay = L.imageOverlay("", guideBoundingRect.getBounds(), {
             opacity: 0.7,
             interactive: true,
             snapIgnore: true,
@@ -71,10 +71,10 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             allowRotation: false,
             draggable: false,
         })
-
         imageOverlayRef.current = imageOverlay;
 
-        guideBoundingRect.setStyle({ fillColor: "white", fillOpacity: .0, fillRule: "evenodd" })
+        // giving the rect a fill color so that it accepts pointer events
+        guideBoundingRect.setStyle({ fillColor: "white", fillOpacity: 0, fillRule: "evenodd" })
         guideBoundingRect.pm.disableRotate()
         guideBoundingRect.pm.setOptions({
             allowEditing: true,
@@ -84,6 +84,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
         })
 
         const guideRotationHandle = L.rectangle(guideBoundingRect.getBounds(), { className: "rotationControler" }).addTo(imageOverlayMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
+
         guideRotationHandle.pm.setOptions({
             allowEditing: false,
             allowRemoval: false,
@@ -96,6 +97,10 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
         guideRotationHandle.setStyle({ fill: false, stroke: false })
 
         guideBoundingRect.on("pm:edit", (e: L.LeafletEvent) => {
+            imageOverlay.setBounds(guideBoundingRect.getBounds())
+            guideRotationHandle.setBounds(guideBoundingRect.getBounds())
+            guideRotationHandle.pm.setInitAngle(0)
+            guideRotationHandle.pm.rotateLayerToAngle(rotationRef.current)
             modifyFloor({
                 data: {
                     id: floorData.databaseId,
@@ -104,11 +109,8 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
                     }
                 }
             })
-            imageOverlay.setBounds(guideBoundingRect.getBounds())
-            guideRotationHandle.setBounds(guideBoundingRect.getBounds())
-            guideRotationHandle.pm.setInitAngle(0)
-            guideRotationHandle.pm.rotateLayerToAngle(rotationRef.current)
         })
+
         hasAlreadyAddedImage.current = true;
     }
 
@@ -160,7 +162,6 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
     }, [debouncedRotation])
 
     useEffect(() => {
-        addEditableImageToFloor();
         if (guideImageUrl === "" || !canvas.current) return;
         getRotatedImage(guideImageUrl)
         if (guideImageUrl === floorData.guideImage) return;

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -86,7 +86,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             setRotation(e.angle)
         })
 
-        guideBoundingRect.on("pm:edit", (e: L.LeafletEvent) => {
+        guideBoundingRect.on("pm:edit", () => {
             imageOverlay.setBounds(guideBoundingRect.getBounds())
             modifyFloor({
                 data: {
@@ -149,6 +149,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
     }, [debouncedRotation])
 
     useEffect(() => {
+        addEditableImageToFloor();
         if (guideImageUrl === "" || !canvas.current) return;
         getRotatedImage(guideImageUrl)
         if (guideImageUrl === floorData.guideImage) return;

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -2,15 +2,12 @@ import { TextInput } from "@mantine/core"
 import { useEffect, useRef, useState } from "react";
 import * as L from "leaflet";
 import { useDebounce } from "../../utils/hooks";
-import { removeAllLayersFromLayerGroup } from "../../utils/utils";
 
 type Props = {
     map: L.Map;
     floorMapLayer: L.GeoJSON;
     setFormError: (error: string) => void;
 }
-
-const imageGuideOverlay = L.geoJSON();
 
 const GuideImage = ({ map, floorMapLayer, setFormError }: Props) => {
     const canvas = useRef<HTMLCanvasElement>(null);
@@ -31,8 +28,8 @@ const GuideImage = ({ map, floorMapLayer, setFormError }: Props) => {
         if (hasAlreadyAddedImageRef.current) return;
         hasAlreadyAddedImageRef.current = true;
         const coords = latLngBounds;
-        imageGuideOverlay.addTo(floorMapLayer)
-        const guideBoundingRect = L.rectangle(coords).addTo(imageGuideOverlay); // the Leaflet constructor always creates a non-rotated rectangle
+        // imageGuideOverlay.addTo(floorMapLayer)
+        const guideBoundingRect = L.rectangle(coords).addTo(floorMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
         guideBoundingRect.setStyle({ fillColor: 'url(#guideBackgroundImage)', fillOpacity: .5, fillRule: "evenodd" })
         guideBoundingRect.pm.disableRotate()
         guideBoundingRect.pm.setOptions({
@@ -56,7 +53,7 @@ const GuideImage = ({ map, floorMapLayer, setFormError }: Props) => {
                 `);
         }
 
-        const guideRotationHandle = L.rectangle(coords).addTo(imageGuideOverlay); // the Leaflet constructor always creates a non-rotated rectangle
+        const guideRotationHandle = L.rectangle(coords).addTo(floorMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
         guideRotationHandle.pm.setOptions({
             allowEditing: false,
             allowRemoval: false,
@@ -119,7 +116,12 @@ const GuideImage = ({ map, floorMapLayer, setFormError }: Props) => {
         img.addEventListener("error", () => {
             setFormError("failed to load guide image");
             hasAlreadyAddedImageRef.current = false;
-            removeAllLayersFromLayerGroup(imageGuideOverlay, map);
+            for(const layer of floorMapLayer.getLayers()){
+                if(layer instanceof L.Rectangle){
+                    map.removeLayer(layer);
+                    floorMapLayer.removeLayer(layer);
+                }
+            }
         })
     }
 

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -42,7 +42,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
         rotationRef.current = debouncedRotation;
     }, [debouncedRotation])
 
-    const startingLatLngBounds = L.latLngBounds([startPos.lat, startPos.lon], [startPos.lat+.0005, startPos.lon+.0005]);
+    const startingLatLngBounds = L.latLngBounds([startPos.lat, startPos.lon], [startPos.lat + .0005, startPos.lon + .0005]);
 
     const clearGuideLayer = () => {
         removeAllLayersFromLayerGroup(imageOverlayMapLayer, map)
@@ -53,10 +53,10 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
         if (hasAlreadyAddedImage.current) return;
 
         let guideBoundingRect: L.Rectangle;
-        if(floorData.guideImageShape) {
+        if (floorData.guideImageShape) {
             const coords = (JSON.parse(floorData.guideImageShape) as GeoJSON.Feature<GeoJSON.Polygon>);
             guideBoundingRect = L.rectangle(L.geoJSON(coords).getBounds()).addTo(imageOverlayMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
-        }else{
+        } else {
             guideBoundingRect = L.rectangle(startingLatLngBounds).addTo(imageOverlayMapLayer);
         }
 
@@ -83,7 +83,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             draggable: true,
         })
 
-        const guideRotationHandle = L.rectangle(guideBoundingRect.getBounds()).addTo(imageOverlayMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
+        const guideRotationHandle = L.rectangle(guideBoundingRect.getBounds(), { className: "rotationControler" }).addTo(imageOverlayMapLayer); // the Leaflet constructor always creates a non-rotated rectangle
         guideRotationHandle.pm.setOptions({
             allowEditing: false,
             allowRemoval: false,
@@ -94,11 +94,6 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             setRotation(e.angle)
         })
         guideRotationHandle.setStyle({ fill: false, stroke: false })
-        const guideRotationHandleElement = guideRotationHandle.getElement()
-
-        if (guideRotationHandleElement) {
-            guideRotationHandleElement.classList.add("rotationControler")
-        }
 
         guideBoundingRect.on("pm:edit", (e: L.LeafletEvent) => {
             modifyFloor({

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -1,0 +1,140 @@
+import { TextInput } from "@mantine/core"
+import { useEffect, useRef, useState } from "react";
+import * as L from "leaflet";
+import { useDebounce } from "../../utils/hooks";
+import { removeAllLayersFromLayerGroup } from "../../utils/utils";
+
+type Props = {
+    map: L.Map;
+    floorMapLayer: L.GeoJSON;
+    setFormError: (error: string) => void;
+}
+
+const imageGuideOverlay = L.geoJSON();
+
+const GuideImage = ({ map, floorMapLayer, setFormError }: Props) => {
+    const canvas = useRef<HTMLCanvasElement>(null);
+    const [rotation, setRotation] = useState<number>(0);
+    const debouncedRotation = useDebounce(rotation, rotation, 100)
+    const hasAlreadyAddedImageRef = useRef<boolean>(false);
+    const rotationRef = useRef<number>(0);
+    const [guideImageUrl, setGuideImageUrl] = useState<string>("");
+
+    useEffect(() => {
+        rotationRef.current = debouncedRotation;
+    }, [debouncedRotation])
+
+
+    var latLngBounds = L.latLngBounds([37.48476370807255, -122.14827817912189], [37.485283029418994, -122.14775246616237]);
+
+    const addEditableImageToFloor = () => {
+        if (hasAlreadyAddedImageRef.current) return;
+        hasAlreadyAddedImageRef.current = true;
+        const coords = latLngBounds;
+        imageGuideOverlay.addTo(floorMapLayer)
+        const guideBoundingRect = L.rectangle(coords).addTo(imageGuideOverlay); // the Leaflet constructor always creates a non-rotated rectangle
+        guideBoundingRect.setStyle({ fillColor: 'url(#guideBackgroundImage)', fillOpacity: .5, fillRule: "evenodd" })
+        guideBoundingRect.pm.disableRotate()
+        guideBoundingRect.pm.setOptions({
+            allowEditing: true,
+            allowRemoval: false,
+            allowRotation: false,
+            draggable: true,
+        })
+
+        const guideBoundingRectElement = guideBoundingRect.getElement()
+
+        if (guideBoundingRectElement) {
+            guideBoundingRectElement.insertAdjacentHTML('beforebegin', `
+                <defs>
+                    <pattern height="100%" width="100%"
+                    patternContentUnits="objectBoundingBox"
+                    preserveAspectRatio="xMidYMid slice"
+                    id="guideBackgroundImage">
+                    </pattern>
+                </defs>
+                `);
+        }
+
+        const guideRotationHandle = L.rectangle(coords).addTo(imageGuideOverlay); // the Leaflet constructor always creates a non-rotated rectangle
+        guideRotationHandle.pm.setOptions({
+            allowEditing: false,
+            allowRemoval: false,
+            allowRotation: true,
+            draggable: false,
+        })
+        guideRotationHandle.on("pm:rotate", (e) => {
+            setRotation(e.angle)
+        })
+        guideRotationHandle.setStyle({ fill: false, stroke: false })
+        const guideRotationHandleElement = guideRotationHandle.getElement()
+
+        if (guideRotationHandleElement) {
+            guideRotationHandleElement.classList.add("rotationControler")
+        }
+
+        guideBoundingRect.on("pm:edit", () => {
+            guideRotationHandle.setBounds(guideBoundingRect.getBounds())
+            guideRotationHandle.pm.setInitAngle(0)
+            guideRotationHandle.pm.rotateLayerToAngle(rotationRef.current)
+        })
+    }
+
+    const drawImage = (canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, image: HTMLImageElement, rotation: number) => {
+        const rotationRadians = rotation * Math.PI / 180;
+        const scaleFacotorH = Math.abs(canvas.width * Math.sin(rotationRadians)) + Math.abs(canvas.height * Math.cos(rotationRadians))
+        const scaleFacotorW = Math.abs(canvas.width * Math.cos(rotationRadians)) + Math.abs(canvas.height * Math.sin(rotationRadians))
+        canvas.height = scaleFacotorH
+        canvas.width = scaleFacotorW
+        ctx.translate(canvas.width / 2, canvas.height / 2);
+        ctx.rotate(rotationRadians);
+        ctx.drawImage(image, -image.width * 0.5, -image.height * 0.5);
+        ctx.restore();
+    }
+    const getRotatedImage = (url: string) => {
+        if (!canvas.current) return;
+        const ctx = canvas.current.getContext("2d")
+        if (!ctx) return;
+        const img = new Image();
+        img.src = url;
+        img.crossOrigin = "anonymous";
+        img.addEventListener("load", () => {
+            if (!canvas.current || !ctx) return
+            canvas.current.height = img.height;
+            canvas.current.width = img.width;
+            ctx.clearRect(0, 0, canvas.current.width, canvas.current.height);
+            drawImage(canvas.current, ctx, img, debouncedRotation)
+            canvas.current.toBlob((blob) => {
+                if (!blob) return;
+                const url = URL.createObjectURL(blob);
+                const patternImage = document.getElementById("guideBackgroundImage");
+                if (!patternImage) {
+                    setFormError("fail to load guide image from canvas")
+                    return;
+                };
+                patternImage.innerHTML = `<image id="patternImage"
+                href="${url}" height="1" width="1" preserveAspectRatio="none"/>`
+            }, 'image/png');
+        });
+        img.addEventListener("error", () => {
+            setFormError("failed to load guide image");
+            hasAlreadyAddedImageRef.current = false;
+            removeAllLayersFromLayerGroup(imageGuideOverlay, map);
+        })
+    }
+
+    useEffect(() => {
+        if (guideImageUrl === "") return;
+        addEditableImageToFloor();
+        getRotatedImage(guideImageUrl)
+    }, [guideImageUrl, canvas.current, debouncedRotation])
+
+    return (
+        <>
+            <canvas style={{ display: "none" }} ref={canvas} id="tutorial" width="600" height="600"></canvas>
+            <TextInput label="Guide Image Url" placeholder="Enter Guide Image Url" onChange={(e) => setGuideImageUrl(e.target.value)} />
+        </>
+    )
+}
+
+export default GuideImage;

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -186,7 +186,7 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
             <canvas style={{ display: "none" }} ref={canvas} id="tutorial" width="600" height="600"></canvas>
             <i>Guide Image is currently experimental</i>
             <TextInput label="Guide Image Url" placeholder="Enter Guide Image Url" value={guideImageUrl} onChange={(e) => setGuideImageUrl(e.target.value)} />
-            <p>Consider using <a href="https://imgbb.com/">https://imgbb.com/</a> to upload your image, then copy the embed url</p>
+            <p>Consider using <a href="https://imgbb.com/">https://imgbb.com/</a> to upload your image, then copy the embed url<br /> *Generally will not work with images not intended to be embedded due to cors</p>
         </>
     )
 }

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/GuideImage.tsx
@@ -62,14 +62,14 @@ const GuideImage = ({ startPos, imageOverlayMapLayer, modifyFloor, currentFloorD
 
         const imageOverlay = L.imageOverlay(guideImageUrl, guideBoundingRect.getBounds(), {
             opacity: 0.7,
-            interactive: true
+            interactive: true,
+            snapIgnore: true,
         }).addTo(imageOverlayMapLayer);
         imageOverlay.pm.setOptions({
             allowEditing: false,
             allowRemoval: false,
             allowRotation: false,
             draggable: false,
-            snappable: false,
         })
 
         imageOverlayRef.current = imageOverlay;

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/styles/BuildingEditorBody.css
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/styles/BuildingEditorBody.css
@@ -47,3 +47,8 @@
 .noAreaSelectedText {
     vertical-align: middle;
 }
+
+
+.rotationControler {
+    pointer-events: none;
+}

--- a/IndoorMapsFrontend/src/schema.graphql
+++ b/IndoorMapsFrontend/src/schema.graphql
@@ -120,6 +120,9 @@ type Floor {
   areas: [Area!]!
   databaseId: Int!
   description: String!
+  guideImage: String
+  guideImageRotation: Float
+  guideImageShape: String
   id: ID!
   shape: String
   title: String!
@@ -133,7 +136,10 @@ input FloorCreateInput {
 
 input FloorModifyInput {
   description: String
+  guideImage: String
+  guideImageRotation: Float
   id: Int!
+  newGuideImageShape: NewShape
 
   """
   If New Shape is null there is no update, otherwise shape is updated to the shape inside of NewShape

--- a/IndoorMapsFrontend/src/utils/hooks.tsx
+++ b/IndoorMapsFrontend/src/utils/hooks.tsx
@@ -65,6 +65,7 @@ export const useRefreshRelayCache = () => {
                 id
                 floors {
                     ...FloorListItemFragment
+                    ...AreaSidebarBodyFragment
                 }
             }
         }

--- a/IndoorMapsFrontend/src/utils/utils.ts
+++ b/IndoorMapsFrontend/src/utils/utils.ts
@@ -1,3 +1,4 @@
+import * as L from "leaflet";
 /**
  * Removes all layers from a layer group and removes them from the map
  * @param layerGroup the layer group to remove all layers from
@@ -38,4 +39,36 @@ export const getAreaOfPolygon = (polygon: L.Polygon): number => {
         sum += (points[i].lng + points[(i + 1)%points.length].lng) * (points[i].lat - points[(i + 1)%points.length].lat)
     }
     return Math.abs(sum / 2)*1000000
+}
+
+//TOTO: fix to make work with irregular shapes
+export const findRectCenter = (rect: L.LatLng[]): L.LatLng  => {
+    const res = new L.LatLng(0, 0);
+    rect.forEach((position) => {
+        res.lat += position.lat;
+        res.lng += position.lng;
+    })
+
+    res.lat /= rect.length;
+    res.lng /= rect.length;
+    return res;
+}
+
+// modified from https://stackoverflow.com/a/13208761
+function rotate_point(point: L.LatLng, origin: L.LatLng, angle: number): L.LatLng {
+    angle = angle * Math.PI / 180.0;
+    console.log(angle);
+    return new L.LatLng(
+        Math.cos(angle) * (point.lat-origin.lat) - Math.sin(angle) * (point.lng-origin.lng) + origin.lat,
+        Math.sin(angle) * (point.lat-origin.lat) + Math.cos(angle) * (point.lng-origin.lng) + origin.lng
+    );
+}
+
+export function rotateRect(rect: L.LatLng[], angle: number): L.LatLng[] {
+    const rotatedPoints = [];
+    for (let i = 0; i < rect.length; i++) {
+        rotatedPoints.push(rotate_point(rect[i], findRectCenter(rect), angle));
+    }
+    console.log(rotatedPoints);
+    return rotatedPoints;
 }


### PR DESCRIPTION
## Description
Building Creator can specify a image url that will then be added to the floor with handles to enable stretching, dragging, and rotating. Leaflet doesn't have anyway to display a rotated image so instead I use HTML canvas to create a new blob:// url of a rotated version of the image based on the current rotation of the handles.

## Milestones
- Map Creators have the ability to upload an existing image of the internal map that then could be used to aid the drawing. The image could be placed onto the GPS map and could then be given a transparency value. Then by drawing on top of the image a more precise map could be created.

## Resources
 - https://leafletjs.com/examples/overlays/

## Test Plan
This is stretch feature so I do not intend to test it as rigorously as the core features.

https://github.com/user-attachments/assets/661880ae-6bf9-408c-ad64-e0e2b8b67b03

