### PR TITLE
Adding Redis Cache for Nav Mesh

### DIFF
--- a/IndoorMapsBackend/package-lock.json
+++ b/IndoorMapsBackend/package-lock.json
@@ -24,6 +24,7 @@
         "graphql-yoga": "^5.6.0",
         "http-proxy": "^1.18.1",
         "jsonwebtoken": "^9.0.2",
+        "redis": "^4.7.0",
         "reflect-metadata": "^0.2.2",
         "type-graphql": "^2.0.0-rc.1",
         "ws": "^8.18.0"
@@ -3547,6 +3548,64 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@repeaterjs/repeater": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
@@ -4742,6 +4801,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5935,6 +6002,14 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -9228,6 +9303,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/reflect-metadata": {

--- a/IndoorMapsBackend/package.json
+++ b/IndoorMapsBackend/package.json
@@ -30,6 +30,7 @@
     "graphql-yoga": "^5.6.0",
     "http-proxy": "^1.18.1",
     "jsonwebtoken": "^9.0.2",
+    "redis": "^4.7.0",
     "reflect-metadata": "^0.2.2",
     "type-graphql": "^2.0.0-rc.1",
     "ws": "^8.18.0"

--- a/IndoorMapsBackend/src/__tests__/nav.tests.ts
+++ b/IndoorMapsBackend/src/__tests__/nav.tests.ts
@@ -90,7 +90,7 @@ describe('Testing the Navigation Resolver and helper functions', () => {
         expect(response.body.data?.getNavBetweenAreas.distance).toBeLessThan(3);
     });
 
-    it('Get Path Standard w/ Cashed Nav Mesh', async () => {
+    it('Get Path Standard w/ Cached Nav Mesh', async () => {
         const testQuery = {
             query: `
             query GetNavBetweenAreas($data: NavigationInput!) {
@@ -123,7 +123,7 @@ describe('Testing the Navigation Resolver and helper functions', () => {
         expect(response.body.data?.getNavBetweenAreas.distance).toBeLessThan(3);
     });
 
-    it('Get Path Voronoi w/ Cashed Nav Mesh', async () => {
+    it('Get Path Voronoi w/ Cached Nav Mesh', async () => {
         const testQuery = {
             query: `
             query GetNavBetweenAreas($data: NavigationInput!) {

--- a/IndoorMapsBackend/src/navMesh/GenerateNavMesh.ts
+++ b/IndoorMapsBackend/src/navMesh/GenerateNavMesh.ts
@@ -151,6 +151,13 @@ export const generateNavMesh = (floor: FloorIncludeAreas, vertexMethod: Pathfind
         }
     })
 
+    // Remove unneeded specificity from floats (because they are stored in json)
+    for (const navVertex of navMesh) {
+        for (const edge of navVertex.edges) {
+            edge.weight = parseFloat(edge.weight.toFixed(6));
+        }
+    }
+
     return [navMesh, areaWalls, floorWalls] as const
 }
 

--- a/IndoorMapsBackend/src/navMesh/GenerateNavMesh.ts
+++ b/IndoorMapsBackend/src/navMesh/GenerateNavMesh.ts
@@ -66,6 +66,19 @@ const expandPolygon = (polygon: Position[], offset: number) => {
     }))
 }
 
+const removeDuplicates = (vertices: LatLng[]) => {
+    const elementTracker: { [key: string]: Boolean } = {};
+    const noDuplicates: LatLng[] = [];
+    for (const vertex of vertices) {
+        let key = vertex.lat + " " + vertex.lon;
+        if (!elementTracker[key]) {
+            elementTracker[key] = true;
+            noDuplicates.push(vertex)
+        }
+    }
+    return noDuplicates;
+}
+
 export const generateNavMesh = (floor: FloorIncludeAreas, vertexMethod: PathfindingMethod): [NavMesh, Wall[], Wall[]] => {
     const floorGeoJSON: GeoJSON.FeatureCollection = floor.shape as unknown as GeoJSON.FeatureCollection;
     // The floor contains may doors (which are type Marker) and 1 outline (which is type shape)
@@ -140,6 +153,8 @@ export const generateNavMesh = (floor: FloorIncludeAreas, vertexMethod: Pathfind
         }))
     }
 
+    vertices = removeDuplicates(vertices);
+
     const navMesh: NavMesh = [];
     extendNavMesh(navMesh, walls, vertices)
 
@@ -197,7 +212,7 @@ export const addAreaToMesh = (navMesh: NavMesh, area: Area | undefined, walls: W
                 walls.filter(wall => {
                     return !((distanceFromPointToLine(entrancePoint, wall) < minDistanceFromDoorToWall) && areaWalls.findIndex((ignorableWall) => {
                         return areWallsEqual(ignorableWall, wall)
-                    }) !== -1 )
+                    }) !== -1)
                 }).concat(floorPerimeterWalls),
                 entrancePoint);
         }

--- a/IndoorMapsBackend/src/resolvers/AreaResolver.ts
+++ b/IndoorMapsBackend/src/resolvers/AreaResolver.ts
@@ -1,4 +1,4 @@
-import { InputType, Field, Int, Resolver, Mutation, Arg, Ctx, Query, FieldResolver, Root } from "type-graphql"
+import { InputType, Field, Int, Resolver, Mutation, Arg, Ctx, Query, FieldResolver, Root, Directive } from "type-graphql"
 import { checkAuthrizedAreaEditor, checkAuthrizedFloorEditor, getUserOrThrowError } from "../auth/validateUser.js"
 import { Context } from "../utils/context.js"
 import { Area, NewAreaResult } from "../graphqlSchemaTypes/Area.js"
@@ -166,6 +166,7 @@ export class AreaResolver {
     // Not currently in use due to performance issues
     @FieldResolver((type) => Floor)
     async floor(
+        @Directive('@deprecated(reason: "slow due to n+1 query problem, use floorTitle instead")')
         @Root() area: Area,
         @Ctx() ctx: Context,
     ) {

--- a/IndoorMapsBackend/src/resolvers/FloorResolver.ts
+++ b/IndoorMapsBackend/src/resolvers/FloorResolver.ts
@@ -7,7 +7,7 @@ import { Floor, NewFloorResult } from "../graphqlSchemaTypes/Floor.js";
 import { Area } from "../graphqlSchemaTypes/Area.js";
 import { throwGraphQLBadInput } from "../utils/generic.js";
 import { Prisma } from "@prisma/client";
-import { invalidateCashe } from "../utils/redisCache.js";
+import { invalidateCache } from "../utils/redisCache.js";
 
 @InputType()
 class FloorCreateInput {
@@ -67,7 +67,7 @@ export const deleteNavMesh = async (floorDatabaseId: number) => {
             floorPerimeterWalls: Prisma.DbNull,
         }
     })
-    invalidateCashe("floor"+floorDatabaseId);
+    invalidateCache("floor"+floorDatabaseId);
 }
 
 @Resolver(of => Floor)

--- a/IndoorMapsBackend/src/resolvers/FloorResolver.ts
+++ b/IndoorMapsBackend/src/resolvers/FloorResolver.ts
@@ -7,6 +7,7 @@ import { Floor, NewFloorResult } from "../graphqlSchemaTypes/Floor.js";
 import { Area } from "../graphqlSchemaTypes/Area.js";
 import { throwGraphQLBadInput } from "../utils/generic.js";
 import { Prisma } from "@prisma/client";
+import { invalidateCashe } from "../utils/redisCache.js";
 
 @InputType()
 class FloorCreateInput {
@@ -66,6 +67,7 @@ export const deleteNavMesh = async (floorDatabaseId: number) => {
             floorPerimeterWalls: Prisma.DbNull,
         }
     })
+    invalidateCashe("floor"+floorDatabaseId);
 }
 
 @Resolver(of => Floor)

--- a/IndoorMapsBackend/src/server.ts
+++ b/IndoorMapsBackend/src/server.ts
@@ -20,6 +20,7 @@ import { FloorResolver } from "./resolvers/FloorResolver.js";
 import { AreaResolver } from "./resolvers/AreaResolver.js";
 import { GeododerResolver } from "./resolvers/AutocompleteResolver.js";
 import { NavResolver } from "./resolvers/NavResolver.js";
+import { initializeRedisClient } from "./utils/redisCache.js";
 
 const app = express();
 export const httpServer = http.createServer(app);
@@ -61,6 +62,8 @@ async function main() {
         },
         ],
     });
+
+    await initializeRedisClient();
 
     await server.start();
 

--- a/IndoorMapsBackend/src/utils/redisCache.ts
+++ b/IndoorMapsBackend/src/utils/redisCache.ts
@@ -1,0 +1,60 @@
+import type { RedisClientType, RedisFunctions, RedisModules, RedisScripts } from '@redis/client';
+import { createClient } from 'redis';
+let redisClient: RedisClientType<RedisModules, RedisFunctions, RedisScripts>;
+
+// cache lifespan in seconds (currently 2 weeks)
+// the cache gets invalidated when the areas are edited so it can be stale for a while
+const cacheLifespan = 60 * 60 * 24 * 14;
+export const initializeRedisClient = async () => {
+    // read the Redis connection URL from the envs
+    let redisURL = process.env.REDIS_URI
+    if (redisURL) {
+        // create the Redis client object
+        redisClient = createClient({ url: redisURL }).on("error", (e) => {
+            console.error(`Failed to create the Redis client with error:`);
+            console.error(e);
+        });
+
+        try {
+            // connect to the Redis server
+            await redisClient.connect();
+            console.log(`Connected to Redis successfully!`);
+        } catch (e) {
+            console.error(`Connection to Redis failed with error:`);
+            console.error(e);
+        }
+    }
+}
+
+const isRedisWorking = () => {
+    // verify wheter there is an active connection
+    // to a Redis server or not
+    return !!redisClient?.isOpen;
+}
+
+export const writeData = async (key: string, data: string) => {
+    if (isRedisWorking()) {
+        try {
+            // write data to the Redis cache
+            await redisClient.set(key, data, { EX: cacheLifespan });
+        } catch (e) {
+            console.error(`Failed to cache data for key=${key}`, e);
+        }
+    }
+}
+
+export const readData = async (key: string) => {
+    let cachedValue = undefined;
+
+    if (isRedisWorking()) {
+        // try to get the cached response from redis
+        cachedValue = await redisClient.get(key);
+        if (cachedValue) {
+            return cachedValue;
+        }
+    }
+}
+
+export const invalidateCashe = async (key: string) => {
+    redisClient.del(key);
+}

--- a/IndoorMapsBackend/src/utils/redisCache.ts
+++ b/IndoorMapsBackend/src/utils/redisCache.ts
@@ -13,7 +13,7 @@ export const initializeRedisClient = async () => {
     const redisPassword = process.env.REDIS_PASSWORD
     if (redisURL || redisHost) {
         // create the Redis client object
-        if(redisHost && redisPort && redisPassword) {
+        if (redisHost && redisPort && redisPassword) {
             redisClient = createClient({
                 password: redisPassword,
                 socket: {
@@ -21,7 +21,7 @@ export const initializeRedisClient = async () => {
                     port: parseInt(redisPort)
                 }
             });
-        }else {
+        } else {
             redisClient = createClient({ url: redisURL }).on("error", (e) => {
                 console.error(`Failed to create the Redis client with error:`);
                 console.error(e);
@@ -68,6 +68,8 @@ export const readData = async (key: string) => {
     }
 }
 
-export const invalidateCashe = async (key: string) => {
-    redisClient.del(key);
+export const invalidateCache = async (key: string) => {
+    if (isRedisWorking()) {
+        await redisClient.del(key);
+    }
 }

--- a/IndoorMapsBackend/src/utils/redisCache.ts
+++ b/IndoorMapsBackend/src/utils/redisCache.ts
@@ -7,13 +7,26 @@ let redisClient: RedisClientType<RedisModules, RedisFunctions, RedisScripts>;
 const cacheLifespan = 60 * 60 * 24 * 14;
 export const initializeRedisClient = async () => {
     // read the Redis connection URL from the envs
-    let redisURL = process.env.REDIS_URI
-    if (redisURL) {
+    const redisURL = process.env.REDIS_URI
+    const redisHost = process.env.REDIS_HOST
+    const redisPort = process.env.REDIS_PORT
+    const redisPassword = process.env.REDIS_PASSWORD
+    if (redisURL || redisHost) {
         // create the Redis client object
-        redisClient = createClient({ url: redisURL }).on("error", (e) => {
-            console.error(`Failed to create the Redis client with error:`);
-            console.error(e);
-        });
+        if(redisHost && redisPort && redisPassword) {
+            redisClient = createClient({
+                password: redisPassword,
+                socket: {
+                    host: redisHost,
+                    port: parseInt(redisPort)
+                }
+            });
+        }else {
+            redisClient = createClient({ url: redisURL }).on("error", (e) => {
+                console.error(`Failed to create the Redis client with error:`);
+                console.error(e);
+            });
+        }
 
         try {
             // connect to the Redis server

--- a/IndoorMapsFrontend/src/App.tsx
+++ b/IndoorMapsFrontend/src/App.tsx
@@ -33,7 +33,9 @@ const router = createBrowserRouter([
         autocompleteInput: {
           p: null,
         },
-        buildingSearchInput: {}
+        buildingSearchInput: {
+          searchQuery: "",
+        }
       },
     ),
   },

--- a/IndoorMapsFrontend/src/components/forms/CreateFloorModal.tsx
+++ b/IndoorMapsFrontend/src/components/forms/CreateFloorModal.tsx
@@ -65,7 +65,7 @@ const CreateFloorModal = ({ isOpen, closeModal }: Props) => {
         <Modal
             opened={isOpen}
             onClose={() => closeModal()}
-            title={"Create a New Building Map"}
+            title={"Create a New Floor"}
             overlayProps={{
                 backgroundOpacity: 0.55,
                 blur: 3,

--- a/IndoorMapsFrontend/src/components/forms/EditBuildingModal.tsx
+++ b/IndoorMapsFrontend/src/components/forms/EditBuildingModal.tsx
@@ -97,7 +97,7 @@ const EditBuildingModal = ({ isOpen, closeModal, getGeocoder, buildingFromParent
         >
             <form method="dialog" onSubmit={form.onSubmit(handleSubmit)}>
                 <FormErrorNotification formError={formError} onClose={() => { setFormError(null) }} />
-                <TextInput {...form.getInputProps('buildingName')} autoComplete="on" label="Building Name (Changing the name will break all links to the building)" placeholder="West Seattle Grocery Central" />
+                <TextInput {...form.getInputProps('buildingName')} autoComplete="on" label="Building Name" placeholder="West Seattle Grocery Central" />
                 <TextInput {...form.getInputProps('address')} autoComplete="address" label="Address" placeholder="123 California Way" />
                 <Suspense fallback={<Loader color="dark-blue" />}>
                     <AutoCompleteResults chooseAutocompleteResult={handleChooseAutocompleteResult} searchString={form.values.address} getGeocoder={getGeocoder} />

--- a/IndoorMapsFrontend/src/routes/BuildingEditor/InviteEditorsModal.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingEditor/InviteEditorsModal.tsx
@@ -61,7 +61,7 @@ const InviteEditorsModal = ({ isOpen, closeModal }: Props) => {
         <Modal
             opened={isOpen}
             onClose={() => closeModal()}
-            title={"Create a New Building Map"}
+            title={"Invite a user to edit this building"}
             overlayProps={{
                 backgroundOpacity: 0.55,
                 blur: 3,

--- a/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
@@ -13,7 +13,7 @@ import type { Subscription } from "relay-runtime/lib/network/RelayObservable";
 const iconCurrentLocation = <IconCurrentLocation style={{ width: rem(16), height: rem(16) }} />
 const iconLocationShare = <IconLocationShare style={{ width: rem(16), height: rem(16) }} />
 const kmToFeet = 3280.84;
-const gpsChangeCooldown = 5000;
+const gpsChangeCooldown = 8000;
 
 type Props = {
     areaToAreaRouteInfo: AreaToAreaRouteInfo,

--- a/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
@@ -186,6 +186,7 @@ const AreaNavigate = ({ buildingId, areaToAreaRouteInfo, setAreaToAreaRouteInfo,
                             },
                             distance: data.getNavBetweenAreas.distance
                         })
+                        setFormError("")
                     } else {
                         const newRouteInfo = {
                             ...areaToAreaRouteInfo,
@@ -199,6 +200,7 @@ const AreaNavigate = ({ buildingId, areaToAreaRouteInfo, setAreaToAreaRouteInfo,
                         newRouteInfo.navMesh = undefined;
                         newRouteInfo.walls = undefined;
                         setAreaToAreaRouteInfo(newRouteInfo)
+                        setFormError("")
                     }
                 }
             });

--- a/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
@@ -68,9 +68,21 @@ const AreaNavigate = ({ buildingId, areaToAreaRouteInfo, setAreaToAreaRouteInfo,
 
     const getUserLocaiton = useUserLocation((position: GeolocationPosition) => {
         console.log(autoGPSReloadCooldown.current)
-        if (isUsingCurrentLocationNav.current && !autoGPSReloadCooldown.current) {
-            autoGPSReloadCooldown.current = setTimeout(() => autoGPSReloadCooldown.current = undefined, gpsChangeCooldown)
-            setFromWithGPS([position.coords.latitude, position.coords.longitude]);
+        if (isUsingCurrentLocationNav.current) {
+            if (!autoGPSReloadCooldown.current) {
+                autoGPSReloadCooldown.current = setTimeout(() => autoGPSReloadCooldown.current = undefined, gpsChangeCooldown)
+                setFromWithGPS([position.coords.latitude, position.coords.longitude]);
+            } else {
+                // if the autoGPSReloadCooldown is active, just change the starting point for the path
+                let newPath = areaToAreaRouteInfoRef.current.path;
+                if (newPath !== undefined && newPath.length > 0) {
+                    newPath[0] = new LatLng(position.coords.latitude, position.coords.longitude);
+                    setAreaToAreaRouteInfo({
+                        ...areaToAreaRouteInfoRef.current,
+                        path: newPath,
+                    })
+                }
+            }
         }
     }, (errorMessage: string) => {
         setFormError(errorMessage);

--- a/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
+++ b/IndoorMapsFrontend/src/routes/BuildingViewer/Navigation/AreaNavigate.tsx
@@ -79,7 +79,7 @@ const AreaNavigate = ({ buildingId, areaToAreaRouteInfo, setAreaToAreaRouteInfo,
                     newPath[0] = new LatLng(position.coords.latitude, position.coords.longitude);
                     setAreaToAreaRouteInfo({
                         ...areaToAreaRouteInfoRef.current,
-                        path: newPath,
+                        path: [...newPath],
                     })
                 }
             }

--- a/IndoorMapsFrontend/src/routes/Root.tsx
+++ b/IndoorMapsFrontend/src/routes/Root.tsx
@@ -21,11 +21,11 @@ const Root = () => {
 
     return (
         <>
-            <HeaderNav showDesktopContent={isNotMobile} getUserFromCookie={getUserFromCookie} pageTitle={"Welcome to IndoorMaps"} currentPage={"/"}/>
+            <HeaderNav showDesktopContent={isNotMobile} getUserFromCookie={getUserFromCookie} pageTitle={"Welcome to IndoorMaps"} currentPage={"/"} />
             <h2>Welcome To IndoorMaps.</h2>
-            <p>IndoorMaps is the easy way to create useful and accurate maps of any building.</p>
+            <p>The easiest free way to create searchable and sharable maps of any building | School | University | Convention Center | Airport | Office</p>
             <p>Find maps on the <Link to={"/directory"}>Directory</Link></p>
-            <Footer className="notDeviceHeightPage" getUserFromCookie={getUserFromCookie} showDesktopContent={isNotMobile}/>
+            <Footer className="notDeviceHeightPage" getUserFromCookie={getUserFromCookie} showDesktopContent={isNotMobile} />
         </>
     )
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <h3 align="center">Indoor Maps</h3>
 
   <p align="center">
-    The easiest free way to map out any building | Schools | Universities | Convention Centers | Airports | Offices 
+    The easiest free way to map out any building | Schools | Universities | Convention Centers | Airports | Offices
     <br />
     <a href="https://indoormaps.onrender.com/">View Live</a>
     ·
@@ -69,6 +69,13 @@ IndoorMaps is the easy way to create useful and accurate maps of any building.
 * A Postgres Server
   * The link to your postgres server will go into your backend .env file
 
+#### Optional
+
+* A Here API Key
+  * Get An API Key at [HERE](https://developer.here.com/)
+* REDIS server
+  * Spin up a local dev server easily with `docker run -p 6379:6379 -it redis/redis-stack-server:latest`
+
 ### Installation
 
 1. Clone the repo
@@ -86,6 +93,12 @@ IndoorMaps is the easy way to create useful and accurate maps of any building.
    FRONTEND_URL="http://localhost:5173"
    # If you don't have a here API key most functionality will still work
    HERE_API_KEY="<Get An API Key at [HERE](https://developer.here.com/)"
+   # All functionality will work without a REDIS cache
+   REDIS_URI="redis://localhost:6379"
+   # you can also connect with a password using
+   REDIS_PASSWORD='******'
+   REDIS_PORT='6379'
+   REDIS_HOST='localhost'
    ```
 4. Enter your frontend env variables in `IndoorMapsFrontend/.env`
    ```sh

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <h3 align="center">Indoor Maps</h3>
 
   <p align="center">
-    The easiest free way to map out any building | Schools | Universities | Convention Centers | Airports | Offices
+    The easiest free way to create searchable and sharable maps of any building | School | University | Convention Center | Airport | Office
     <br />
     <a href="https://indoormaps.onrender.com/">View Live</a>
     ·


### PR DESCRIPTION
## Description
In and effort to reduce the egress from my main postgres db (as I am quickly reaching this months maximum) and as part of my continual battle to improve performance of the navigation I decided to used Redis to cache the Nav Mesh data. 
- I also made some optimizations to my navMesh generation algo in order to reduce the final size of the mesh, see the Perf commits below
- I initially imagined the Redis server living on the same server instance as my graphql server but I could not find a easy way to run Redis in my Node.js envierment without refactoring everything into a docker container. I have turned to the redislabs free plan which only allows for 30 mb of cache. This should be enough for about 20 detailed floor plans

## Milestones
- N/A

## Resources
- https://semaphoreci.com/blog/nodejs-caching-layer-redis
- https://www.npmjs.com/package/redis

## Test Plan
My largest map on the Prod website now averages at about 500 ms thanks to the speed of Redis and not needing to parse through as much data. 
For the perf commits I generated nav meshs before and after the change to find the % reduction in storage size.